### PR TITLE
[Workflow] Update manual generate workflows

### DIFF
--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -5,7 +5,7 @@ on:
 
       buildVariant:
         type: choice
-        description: 'Build Variant'     
+        description: 'Build Variant'
         required: true
         default: 'NormalOptimized'
         options: 
@@ -19,27 +19,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Set Env Var(s)
+        run: |
+          echo "VALID_TAGS_COUNT=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_ENV
+
+      - name: Fetch upstream tags # required for git describe to return a valid version and to preevnt androidGitVersion from crashing on a new fork
+        if: ${{ env.VALID_TAGS_COUNT == '0' }}
+        run: |
+          # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
+          git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
+          git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
         
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
         
-      #- name: Setup SDK
-      #  uses: android-actions/setup-android@v2
+      #- name: Setup SDK # gradlew will install SDK automatically, thus this step not needed
+      #  uses: android-actions/setup-android@v3
           
-      #- name: Setup NDK
+      #- name: Setup NDK # gradle will install NDK (side by side) automatically, thus explictly seting up NDK here will cause not enough storage issue when building debug variant
       #  uses: nttld/setup-ndk@v1
       #  with:
       #    ndk-version: r21e
+
+      - name: Test androidGitVersion
+        run: gradle --quiet androidGitVersion
       
       - name: Assemble APK
-        run: bash ./gradlew assemble${{ github.event.inputs.buildVariant }} --stacktrace
+        run: ./gradlew assemble${{ github.event.inputs.buildVariant }} --stacktrace
       
       #- name: Gradle Test
       #  run: bash ./gradlew test${{ github.event.inputs.buildVariant }}UnitTest --stacktrace
@@ -48,14 +63,12 @@ jobs:
         run: |
           find . -name "*.apk"
           mkdir ppsspp
-          if [ -e android/build/*/apk/*/*/android-normal-optimized.apk ]; then
-            cp android/build/*/apk/*/*/android-normal-optimized.apk ppsspp/
-          elif [ -e android/build/*/apk/*/*/android-normal-debug.apk ]; then
-            cp android/build/*/apk/*/*/android-normal-debug.apk ppsspp/
+          if [ -e android/build/*/apk/*/*/*.apk ]; then
+            cp android/build/*/apk/*/*/*.apk ppsspp/
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-${{ github.event.inputs.buildVariant }} build
           path: ppsspp/

--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -24,12 +24,13 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Set Env Var(s)
+      - name: Check Valid Version Tags
+        id: valid-tags
         run: |
-          echo "VALID_TAGS_COUNT=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_ENV
+          echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
 
       - name: Fetch upstream tags # required for git describe to return a valid version and to preevnt androidGitVersion from crashing on a new fork
-        if: ${{ env.VALID_TAGS_COUNT == '0' }}
+        if: ${{ steps.valid-tags.outputs.count == '0' }}
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback

--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Check Valid Version Tags
         id: valid-tags
+        shell: bash
         run: |
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
 
@@ -52,7 +53,9 @@ jobs:
       #    ndk-version: r21e
 
       - name: Test androidGitVersion
-        run: gradle --quiet androidGitVersion
+        run: |
+          echo "count ${{steps.valid-tags.outputs.count}}"
+          gradle --quiet androidGitVersion
       
       - name: Assemble APK
         run: ./gradlew assemble${{ github.event.inputs.buildVariant }} --stacktrace

--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Test androidGitVersion
         run: |
-          echo "count ${{steps.valid-tags.outputs.count}}"
+          echo "count=${{steps.valid-tags.outputs.count}}"
           gradle --quiet androidGitVersion
       
       - name: Assemble APK

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
         
-      - name: Valid Version Tags
+      - name: Check Valid Version Tags
         id: valid-tags
         run: |
           git tag v0.0.1
@@ -40,7 +40,14 @@ jobs:
       - name: Set Env Var(s)
         run: |
           echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
+          echo "Content of [GIT_VERSION] = ${GIT_VERSION}"
+          echo "Content of [GITHUB_ENV] = ${github.env}"
+          echo "Content of [GITHUB_OUTPUT] = ${github.output}"
+          echo "Content of [[GIT_VERSION]] = ${{GIT_VERSION}}"
+          echo "Content of [[GITHUB_ENV]] = ${{github.env}}"
+          echo "Content of [[GITHUB_OUTPUT]] = ${{github.output}}"
           env
+          output
         
       - name: Create macOS git-version.cpp & Version.txt
         run: |

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Valid Version Tags
         id: valid-tags
         run: |
-          # git tag v0.0.1
+          git tag v0.0.1
           echo "count=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_OUTPUT
 
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
@@ -40,6 +40,7 @@ jobs:
       - name: Set Env Var(s)
         run: |
           echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
+          env
         
       - name: Create macOS git-version.cpp & Version.txt
         run: |

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -28,7 +28,7 @@ jobs:
         id: valid-tags
         run: |
           git tag v0.0.1
-          echo "count=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_OUTPUT
+          echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
 
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
         if: ${{ steps.valid-tags.outputs.count == '0' }}

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -5,7 +5,7 @@ on:
 
       buildVariant:
         type: choice
-        description: 'Build Variant'     
+        description: 'Build Variant'
         required: true
         default: 'release'
         options: 
@@ -19,19 +19,22 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
         
-      #- name: Fetch tags for macOS
-      #  # This is required for git describe --always to work for git-version.cpp.
-      #  run: |
-      #    git fetch --deepen=15000 --no-recurse-submodules --tags || exit 0
-
       - name: Set Env Var(s)
         run: |
+          echo "VALID_TAGS_COUNT=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_ENV
           echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
+
+      - name: Fetch upstream tags # required for git describe to return a valid version
+        if: ${{ env.VALID_TAGS_COUNT == '0' }}
+        run: |
+          # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
+          git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
+          git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
         
       - name: Create macOS git-version.cpp & Version.txt
         run: |
@@ -78,7 +81,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: iOS-${{ github.event.inputs.buildVariant }} build
           path: ppsspp/

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -24,17 +24,22 @@ jobs:
           fetch-depth: 0
           submodules: recursive
         
-      - name: Set Env Var(s)
+      - name: Valid Version Tags
+        id: valid-tags
         run: |
-          echo "VALID_TAGS_COUNT=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_ENV
-          echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
+          git tag v0.0.1
+          echo "count=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_OUTPUT
 
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
-        if: ${{ env.VALID_TAGS_COUNT == '0' }}
+        if: ${{ steps.valid-tags.outputs.count == '0' }}
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
           git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
+
+      - name: Set Env Var(s)
+        run: |
+          echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
         
       - name: Create macOS git-version.cpp & Version.txt
         run: |

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Check Valid Version Tags
         id: valid-tags
         run: |
-          git tag v0.0.1
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
 
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
@@ -40,13 +39,6 @@ jobs:
       - name: Set Env Var(s)
         run: |
           echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
-          echo "Content of [GIT_VERSION] = ${GIT_VERSION}"
-          echo "Content of [github.env] = ${{github.env}}"
-          echo "Content of [github.output] = ${{github.output}}"
-          echo "Content of [env.GITHUB_OUTPUT] = ${{env.GITHUB_OUTPUT}}"
-          echo "Content of [steps.valid-tags.outputs.count] = ${{steps.valid-tags.outputs.count}}"
-          env
-          output
         
       - name: Create macOS git-version.cpp & Version.txt
         run: |

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -44,6 +44,7 @@ jobs:
           echo "Content of [github.env] = ${{github.env}}"
           echo "Content of [github.output] = ${{github.output}}"
           echo "Content of [env.GITHUB_OUTPUT] = ${{env.GITHUB_OUTPUT}}"
+          echo "Content of [steps.valid-tags.outputs.count] = ${{steps.valid-tags.outputs.count}}"
           env
           output
         

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -41,11 +41,9 @@ jobs:
         run: |
           echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
           echo "Content of [GIT_VERSION] = ${GIT_VERSION}"
-          echo "Content of [GITHUB_ENV] = ${github.env}"
-          echo "Content of [GITHUB_OUTPUT] = ${github.output}"
-          echo "Content of [[GIT_VERSION]] = ${{GIT_VERSION}}"
-          echo "Content of [[GITHUB_ENV]] = ${{github.env}}"
-          echo "Content of [[GITHUB_OUTPUT]] = ${{github.output}}"
+          echo "Content of [github.env] = ${github.env}"
+          echo "Content of [github.output] = ${github.output}"
+          echo "Content of [env.GITHUB_OUTPUT] = ${env.GITHUB_OUTPUT}"
           env
           output
         

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -29,7 +29,7 @@ jobs:
           echo "VALID_TAGS_COUNT=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_ENV
           echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
 
-      - name: Fetch upstream tags # required for git describe to return a valid version
+      - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
         if: ${{ env.VALID_TAGS_COUNT == '0' }}
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -41,9 +41,9 @@ jobs:
         run: |
           echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
           echo "Content of [GIT_VERSION] = ${GIT_VERSION}"
-          echo "Content of [github.env] = ${github.env}"
-          echo "Content of [github.output] = ${github.output}"
-          echo "Content of [env.GITHUB_OUTPUT] = ${env.GITHUB_OUTPUT}"
+          echo "Content of [github.env] = ${{github.env}}"
+          echo "Content of [github.output] = ${{github.output}}"
+          echo "Content of [env.GITHUB_OUTPUT] = ${{env.GITHUB_OUTPUT}}"
           env
           output
         

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Valid Version Tags
         id: valid-tags
         run: |
-          git tag v0.0.1
+          # git tag v0.0.1
           echo "count=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_OUTPUT
 
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -26,6 +26,7 @@ jobs:
         
       - name: Check Valid Version Tags
         id: valid-tags
+        shell: bash
         run: |
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
 
@@ -50,6 +51,7 @@ jobs:
           echo $(echo $GIT_VERSION | cut -c 2-) > build-ios/PPSSPP.app/Version.txt
           # Testing values ...
           echo "Content of [GITHUB_REF##*/] = ${GITHUB_REF##*/}"
+          echo "count ${{steps.valid-tags.outputs.count}}"
           echo $(echo $GIT_VERSION | cut -c 2-)
           # Testing file location ...
           find . -name "Version.txt"

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -51,7 +51,7 @@ jobs:
           echo $(echo $GIT_VERSION | cut -c 2-) > build-ios/PPSSPP.app/Version.txt
           # Testing values ...
           echo "Content of [GITHUB_REF##*/] = ${GITHUB_REF##*/}"
-          echo "count ${{steps.valid-tags.outputs.count}}"
+          echo "count=${{steps.valid-tags.outputs.count}}"
           echo $(echo $GIT_VERSION | cut -c 2-)
           # Testing file location ...
           find . -name "Version.txt"

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -39,7 +39,6 @@ jobs:
         id: valid-tags
         shell: bash
         run: |
-          git tag v0.0.1
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
           
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Check Valid Version Tags
         id: valid-tags
-        # shell: bash
+        shell: bash
         run: |
           git tag v0
           echo "count0=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_OUTPUT

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Check Valid Version Tags
         id: valid-tags
         run: |
+          git tag v0.0.1
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
           
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -69,7 +69,7 @@ jobs:
           echo "Content of [[github.workspace]] = ${{github.workspace}}"
           echo "double ${{ github.event.inputs.buildConfiguration }}"
           echo ${{github.workspace}}
-          echo "count ${steps.valid-tags.outputs.count}"
+          echo "count ${{steps.valid-tags.outputs.count}}"
           echo "single ${ github.event.inputs.buildConfiguration }"
           echo $env:GITHUB_WORKSPACE
       

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -35,12 +35,13 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Set Env Var(s)
+      - name: Check Valid Version Tags
+        id: valid-tags
         run: |
-          echo "VALID_TAGS_COUNT=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_ENV
+          echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
           
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
-        if: ${{ env.VALID_TAGS_COUNT == '0' }}
+        if: ${{ steps.valid-tags.outputs.count == '0' }}
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
@@ -68,6 +69,7 @@ jobs:
           echo "Content of [[github.workspace]] = ${{github.workspace}}"
           echo "double ${{ github.event.inputs.buildConfiguration }}"
           echo ${{github.workspace}}
+          echo ${{steps.valid-tags.outputs.count}}
           echo "single ${ github.event.inputs.buildConfiguration }"
           echo $env:GITHUB_WORKSPACE
       

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -39,12 +39,7 @@ jobs:
         id: valid-tags
         shell: bash
         run: |
-          git tag v0
-          echo "count0=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_OUTPUT
-          # echo "count1=$(git tag -l 'v[0-9]*' | wc -l | bc)" >> $GITHUB_OUTPUT
-          echo "count2=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
-          echo "count3=$(git tag -l 'v[0-9]*' | wc -l | awk '{print $1}')" >> $GITHUB_OUTPUT
-          echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
+          echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT # $env:GITHUB_OUTPUT on pwsh
           
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
         if: ${{ steps.valid-tags.outputs.count == '0' }}
@@ -76,10 +71,6 @@ jobs:
           echo "double ${{ github.event.inputs.buildConfiguration }}"
           echo ${{github.workspace}}
           echo "count=${{steps.valid-tags.outputs.count}}"
-          echo "count0=${{steps.valid-tags.outputs.count0}}"
-          # echo "count1=${{steps.valid-tags.outputs.count1}}"
-          echo "count2=${{steps.valid-tags.outputs.count2}}"
-          echo "count3=${{steps.valid-tags.outputs.count3}}"
           echo "single ${ github.event.inputs.buildConfiguration }"
           echo $env:GITHUB_WORKSPACE
       

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -69,7 +69,7 @@ jobs:
           echo "Content of [[github.workspace]] = ${{github.workspace}}"
           echo "double ${{ github.event.inputs.buildConfiguration }}"
           echo ${{github.workspace}}
-          echo ${{steps.valid-tags.outputs.count}}
+          echo "count ${steps.valid-tags.outputs.count}"
           echo "single ${ github.event.inputs.buildConfiguration }"
           echo $env:GITHUB_WORKSPACE
       

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -40,10 +40,10 @@ jobs:
         # shell: bash
         run: |
           git tag v0
-          echo "count0=$(git tag -l 'v[0-9]*' | wc -l)"
-          # echo "count1=$(git tag -l 'v[0-9]*' | wc -l | bc)"
-          echo "count2=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')"
-          echo "count3=$(git tag -l 'v[0-9]*' | wc -l | awk '{print $1}')"
+          echo "count0=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_OUTPUT
+          # echo "count1=$(git tag -l 'v[0-9]*' | wc -l | bc)" >> $GITHUB_OUTPUT
+          echo "count2=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
+          echo "count3=$(git tag -l 'v[0-9]*' | wc -l | awk '{print $1}')" >> $GITHUB_OUTPUT
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
           
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
@@ -75,7 +75,11 @@ jobs:
           echo "Content of [[github.workspace]] = ${{github.workspace}}"
           echo "double ${{ github.event.inputs.buildConfiguration }}"
           echo ${{github.workspace}}
-          echo "count ${{steps.valid-tags.outputs.count}}"
+          echo "count=${{steps.valid-tags.outputs.count}}"
+          echo "count0=${{steps.valid-tags.outputs.count0}}"
+          # echo "count1=${{steps.valid-tags.outputs.count1}}"
+          echo "count2=${{steps.valid-tags.outputs.count2}}"
+          echo "count3=${{steps.valid-tags.outputs.count3}}"
           echo "single ${ github.event.inputs.buildConfiguration }"
           echo $env:GITHUB_WORKSPACE
       

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -23,11 +23,11 @@ on:
         - ARM64
         - ARM
 
-      unsigned:
+      signedPackage:
         type: boolean
-        description: 'Unsigned Package'
+        description: 'Signed Package'
         required: true
-        default: false
+        default: true
 
 jobs:
 
@@ -87,7 +87,7 @@ jobs:
         if: ${{ github.event.inputs.buildPlatform != 'Bundle' }}
         run: |
           echo "include symbols = ${{ env.INCLUDE_SYMBOLS }}"
-          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=${{ github.event.inputs.buildPlatform }} /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=${{ !github.event.inputs.unsigned }} /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Never /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="${{ github.event.inputs.buildPlatform }}"
+          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=${{ github.event.inputs.buildPlatform }} /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=${{ github.event.inputs.signedPackage }} /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Never /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="${{ github.event.inputs.buildPlatform }}"
 
       - name: Execute MSIXBundle build
         working-directory: ${{ github.workspace }}
@@ -96,7 +96,7 @@ jobs:
         if: ${{ github.event.inputs.buildPlatform == 'Bundle' }}
         run: |
           echo "include symbols = ${{ env.INCLUDE_SYMBOLS }}"
-          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=x64 /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=${{ !github.event.inputs.unsigned }} /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Always /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="x64|ARM64|ARM"
+          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=x64 /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=${{ github.event.inputs.signedPackage }} /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Always /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="x64|ARM64|ARM"
           
       - name: Package build
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -39,7 +39,7 @@ jobs:
         id: valid-tags
         run: |
           git tag v0.0.1
-          echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
+          bash echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
           
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
         if: ${{ steps.valid-tags.outputs.count == '0' }}

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -30,13 +30,24 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Set Env Var(s)
+        run: |
+          echo "VALID_TAGS_COUNT=$(git tag -l 'v[0-9]*' | wc -l)" >> $GITHUB_ENV
+          
+      - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
+        if: ${{ env.VALID_TAGS_COUNT == '0' }}
+        run: |
+          # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
+          git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
+          git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
         
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
           
       #- name: Setup cache # We probably need something like MSBuildCache for MSBuild to be able to use cache properly
       #  id: cache-uwp
@@ -91,7 +102,7 @@ jobs:
           #ls ppsspp
           
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: UWP-${{ github.event.inputs.buildConfiguration }}-${{ github.event.inputs.buildPlatform }} build
           path: ppsspp/

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -39,6 +39,10 @@ jobs:
         id: valid-tags
         shell: bash
         run: |
+          git tag v0
+          echo "count1=$(git tag -l 'v[0-9]*' | wc -l | bc)"
+          echo "count2=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')"
+          echo "count3=$(git tag -l 'v[0-9]*' | wc -l | awk '{print $1}')"
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
           
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Check Valid Version Tags
         id: valid-tags
-        shell: bash
+        # shell: bash
         run: |
           git tag v0
           echo "count1=$(git tag -l 'v[0-9]*' | wc -l | bc)"

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -23,6 +23,12 @@ on:
         - ARM64
         - ARM
 
+      unsigned:
+        type: boolean
+        description: 'Unsigned Package'
+        required: true
+        default: false
+
 jobs:
 
   build-uwp:
@@ -81,7 +87,7 @@ jobs:
         if: ${{ github.event.inputs.buildPlatform != 'Bundle' }}
         run: |
           echo "include symbols = ${{ env.INCLUDE_SYMBOLS }}"
-          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=${{ github.event.inputs.buildPlatform }} /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=true /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Never /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="${{ github.event.inputs.buildPlatform }}"
+          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=${{ github.event.inputs.buildPlatform }} /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=${{ !github.event.inputs.unsigned }} /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Never /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="${{ github.event.inputs.buildPlatform }}"
 
       - name: Execute MSIXBundle build
         working-directory: ${{ github.workspace }}
@@ -90,7 +96,7 @@ jobs:
         if: ${{ github.event.inputs.buildPlatform == 'Bundle' }}
         run: |
           echo "include symbols = ${{ env.INCLUDE_SYMBOLS }}"
-          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=x64 /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=true /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Always /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="x64|ARM64|ARM"
+          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=x64 /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=${{ !github.event.inputs.unsigned }} /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Always /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="x64|ARM64|ARM"
           
       - name: Package build
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -40,7 +40,8 @@ jobs:
         # shell: bash
         run: |
           git tag v0
-          echo "count1=$(git tag -l 'v[0-9]*' | wc -l | bc)"
+          echo "count0=$(git tag -l 'v[0-9]*' | wc -l)"
+          # echo "count1=$(git tag -l 'v[0-9]*' | wc -l | bc)"
           echo "count2=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')"
           echo "count3=$(git tag -l 'v[0-9]*' | wc -l | awk '{print $1}')"
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -37,9 +37,10 @@ jobs:
 
       - name: Check Valid Version Tags
         id: valid-tags
+        shell: bash
         run: |
           git tag v0.0.1
-          bash echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
+          echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
           
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
         if: ${{ steps.valid-tags.outputs.count == '0' }}


### PR DESCRIPTION
Fixes version issue on a new fork without any valid version tag (ie. `v[0-9]*`) existed yet, causing `git describe` to return a hash-like value, and also causing `androidGitVersion` in `build.gradle` to crash.