### PR TITLE
[Workflow] Update manual generate workflows

### DIFF
--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -5,7 +5,7 @@ on:
 
       buildVariant:
         type: choice
-        description: 'Build Variant'     
+        description: 'Build Variant'
         required: true
         default: 'NormalOptimized'
         options: 
@@ -19,27 +19,46 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Check Valid Version Tags
+        id: valid-tags
+        shell: bash
+        run: |
+          echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
+
+      - name: Fetch upstream tags # required for git describe to return a valid version and to preevnt androidGitVersion from crashing on a new fork
+        if: ${{ steps.valid-tags.outputs.count == '0' }}
+        run: |
+          # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
+          git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
+          git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
         
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
         
-      #- name: Setup SDK
-      #  uses: android-actions/setup-android@v2
+      #- name: Setup SDK # gradlew will install SDK automatically, thus this step not needed
+      #  uses: android-actions/setup-android@v3
           
-      #- name: Setup NDK
+      #- name: Setup NDK # gradle will install NDK (side by side) automatically, thus explictly seting up NDK here will cause not enough storage issue when building debug variant
       #  uses: nttld/setup-ndk@v1
       #  with:
       #    ndk-version: r21e
+
+      - name: Test androidGitVersion
+        run: |
+          echo "count=${{steps.valid-tags.outputs.count}}"
+          gradle --quiet androidGitVersion
       
       - name: Assemble APK
-        run: bash ./gradlew assemble${{ github.event.inputs.buildVariant }} --stacktrace
+        run: ./gradlew assemble${{ github.event.inputs.buildVariant }} --stacktrace
       
       #- name: Gradle Test
       #  run: bash ./gradlew test${{ github.event.inputs.buildVariant }}UnitTest --stacktrace
@@ -48,14 +67,12 @@ jobs:
         run: |
           find . -name "*.apk"
           mkdir ppsspp
-          if [ -e android/build/*/apk/*/*/android-normal-optimized.apk ]; then
-            cp android/build/*/apk/*/*/android-normal-optimized.apk ppsspp/
-          elif [ -e android/build/*/apk/*/*/android-normal-debug.apk ]; then
-            cp android/build/*/apk/*/*/android-normal-debug.apk ppsspp/
+          if [ -e android/build/*/apk/*/*/*.apk ]; then
+            cp android/build/*/apk/*/*/*.apk ppsspp/
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-${{ github.event.inputs.buildVariant }} build
           path: ppsspp/

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -5,7 +5,7 @@ on:
 
       buildVariant:
         type: choice
-        description: 'Build Variant'     
+        description: 'Build Variant'
         required: true
         default: 'release'
         options: 
@@ -19,15 +19,23 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
         
-      #- name: Fetch tags for macOS
-      #  # This is required for git describe --always to work for git-version.cpp.
-      #  run: |
-      #    git fetch --deepen=15000 --no-recurse-submodules --tags || exit 0
+      - name: Check Valid Version Tags
+        id: valid-tags
+        shell: bash
+        run: |
+          echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
+
+      - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
+        if: ${{ steps.valid-tags.outputs.count == '0' }}
+        run: |
+          # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
+          git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
+          git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
 
       - name: Set Env Var(s)
         run: |
@@ -43,6 +51,7 @@ jobs:
           echo $(echo $GIT_VERSION | cut -c 2-) > build-ios/PPSSPP.app/Version.txt
           # Testing values ...
           echo "Content of [GITHUB_REF##*/] = ${GITHUB_REF##*/}"
+          echo "count=${{steps.valid-tags.outputs.count}}"
           echo $(echo $GIT_VERSION | cut -c 2-)
           # Testing file location ...
           find . -name "Version.txt"
@@ -78,7 +87,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: iOS-${{ github.event.inputs.buildVariant }} build
           path: ppsspp/

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -23,6 +23,12 @@ on:
         - ARM64
         - ARM
 
+      signedPackage:
+        type: boolean
+        description: 'Signed Package'
+        required: true
+        default: true
+
 jobs:
 
   build-uwp:
@@ -30,13 +36,26 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Check Valid Version Tags
+        id: valid-tags
+        shell: bash
+        run: |
+          echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT # $env:GITHUB_OUTPUT on pwsh
+          
+      - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
+        if: ${{ steps.valid-tags.outputs.count == '0' }}
+        run: |
+          # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
+          git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
+          git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
         
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
           
       #- name: Setup cache # We probably need something like MSBuildCache for MSBuild to be able to use cache properly
       #  id: cache-uwp
@@ -57,6 +76,7 @@ jobs:
           echo "Content of [[github.workspace]] = ${{github.workspace}}"
           echo "double ${{ github.event.inputs.buildConfiguration }}"
           echo ${{github.workspace}}
+          echo "count=${{steps.valid-tags.outputs.count}}"
           echo "single ${ github.event.inputs.buildConfiguration }"
           echo $env:GITHUB_WORKSPACE
       
@@ -67,7 +87,7 @@ jobs:
         if: ${{ github.event.inputs.buildPlatform != 'Bundle' }}
         run: |
           echo "include symbols = ${{ env.INCLUDE_SYMBOLS }}"
-          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=${{ github.event.inputs.buildPlatform }} /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=true /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Never /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="${{ github.event.inputs.buildPlatform }}"
+          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=${{ github.event.inputs.buildPlatform }} /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=${{ github.event.inputs.signedPackage }} /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Never /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="${{ github.event.inputs.buildPlatform }}"
 
       - name: Execute MSIXBundle build
         working-directory: ${{ github.workspace }}
@@ -76,7 +96,7 @@ jobs:
         if: ${{ github.event.inputs.buildPlatform == 'Bundle' }}
         run: |
           echo "include symbols = ${{ env.INCLUDE_SYMBOLS }}"
-          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=x64 /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=true /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Always /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="x64|ARM64|ARM"
+          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=x64 /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=${{ github.event.inputs.signedPackage }} /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Always /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="x64|ARM64|ARM"
           
       - name: Package build
         working-directory: ${{ github.workspace }}
@@ -91,7 +111,7 @@ jobs:
           #ls ppsspp
           
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: UWP-${{ github.event.inputs.buildConfiguration }}-${{ github.event.inputs.buildPlatform }} build
           path: ppsspp/


### PR DESCRIPTION
- Fixes version issue on a new fork without any valid version tag (ie. `v[0-9]*`) existed yet, causing `git describe` to return a partial hash value instead of a version number, and also causing `androidGitVersion` in `build.gradle` to crash.
- Added an option to enable/disable Package Signing on UWP  builds.