### PR TITLE
[Adhoc] Attempt to prevent sockets lingering in TIME_WAIT state after closure

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -429,7 +429,11 @@ void deleteAllAdhocSockets() {
 
 			if (fd > 0) {
 				// Close Socket
-				shutdown(fd, SD_BOTH);
+				struct linger sl {};
+				sl.l_onoff = 1;		// non-zero value enables linger option in kernel
+				sl.l_linger = 0;	// timeout interval in seconds
+				setsockopt(fd, SOL_SOCKET, SO_LINGER, (const char*)&sl, sizeof(sl));
+				shutdown(fd, SD_RECEIVE);
 				closesocket(fd);
 			}
 			// Free Memory

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -111,6 +111,10 @@ inline bool isDisconnected(int errcode) { return (errcode == EPIPE || errcode ==
 #define POLLPRI POLL_PRI
 #endif
 
+#ifndef SD_RECEIVE
+#define SD_RECEIVE SHUT_RD //0x00
+#endif
+
 #ifndef SD_BOTH
 #define SD_BOTH SHUT_RDWR //0x02
 #endif

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -2212,7 +2212,7 @@ int NetAdhocPdp_Delete(int id, int unknown) {
 				sl.l_onoff = 1;		// non-zero value enables linger option in kernel
 				sl.l_linger = 0;	// timeout interval in seconds
 				setsockopt(sock->data.pdp.id, SOL_SOCKET, SO_LINGER, (const char*)&sl, sizeof(sl));
-				shutdown(sock->data.pdp.id, SD_BOTH);
+				shutdown(sock->data.pdp.id, SD_RECEIVE);
 				closesocket(sock->data.pdp.id);
 
 				// Remove Port Forward from Router

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -3922,7 +3922,7 @@ int NetAdhocPtp_Close(int id, int unknown) {
 				sl.l_onoff = 1;		// non-zero value enables linger option in kernel
 				sl.l_linger = 0;	// timeout interval in seconds
 				setsockopt(socket->data.ptp.id, SOL_SOCKET, SO_LINGER, (const char*)&sl, sizeof(sl));
-				shutdown(socket->data.ptp.id, SD_BOTH);
+				shutdown(socket->data.ptp.id, SD_RECEIVE);
 				closesocket(socket->data.ptp.id);
 
 				// Remove Port Forward from Router


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/58506815/how-to-apply-linger-option-with-winsock2
Which might be related to port remapping (ie. "Data from Unknown Port") issue on external/public IP, quoted from NAT traversal:
> if two internal hosts attempt to communicate with the same external host using the same port number, the NAT may attempt to use a different external IP address for the second connection or may need to forgo port preservation and remap the port.